### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/isogr-snapshooter/README.adoc
+++ b/isogr-snapshooter/README.adoc
@@ -24,7 +24,7 @@ This folder consists of:
 
 == Prerequisites
 
-* https://nixos.org/[Nix^] (with https://nixos.wiki/wiki/Flakes[flake^] and https://github.com/nix-community/nix-direnv[`nix-direnv`^] support)
+* https://nixos.org/[Nix^] (with https://wiki.nixos.org/wiki/Flakes[flake^] and https://github.com/nix-community/nix-direnv[`nix-direnv`^] support)
 
 If Nix is not installed, then the following prerequisites must be met:
 


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️